### PR TITLE
Fix error with large numbers

### DIFF
--- a/ipyxact/ipyxact.py
+++ b/ipyxact/ipyxact.py
@@ -35,7 +35,7 @@ else:
 class IpxactInt(int):
     def __new__(cls, *args, **kwargs):
         if not args:
-            return super(IpxactInt, cls).__new__(cls)
+            return int()
 
         expr = args[0]
         base = 10
@@ -59,7 +59,7 @@ class IpxactInt(int):
                 raise ValueError("Could not convert expression to an integer: {}".format(args[0]))
             expr = expr[sep+2:]
 
-        return super(IpxactInt, cls).__new__(cls, expr.replace('_', ''), base)
+        return int(expr.replace('_', ''), base)
 
 class IpxactBool(str):
     def __new__(cls, *args, **kwargs):

--- a/ipyxact/ipyxact.py
+++ b/ipyxact/ipyxact.py
@@ -37,7 +37,7 @@ class IpxactInt(int):
         if not args:
             return int()
 
-        expr = args[0]
+        expr = args[0].strip()
         base = 10
 
         if len(expr) > 2 and expr[0:2] == '0x':


### PR DESCRIPTION
Creating `IpxactInt` objects with large values (over 32bit) fail with 
```
OverflowError: Python int too large to convert to C long
```

Instantiation a new `int()` in the class in stead of calling the `super` fixes the issue.