### PR TITLE
Avoid YAML warning by specifying safe loader

### DIFF
--- a/ipyxact/ipyxact.py
+++ b/ipyxact/ipyxact.py
@@ -187,4 +187,4 @@ def _generate_classes(j):
         generatedClass = type(tag[0].upper()+tag[1:], (IpxactItem,), _items)
         globals()[generatedClass.__name__] = generatedClass
 
-_generate_classes(yaml.load(ipxact_yaml.description))
+_generate_classes(yaml.safe_load(ipxact_yaml.description))


### PR DESCRIPTION
This fixes the same YAML loader warning as olofk/fusesoc#249 by specifying the safe loader via the shortcut method.