### PR TITLE
fix syntax error on line 81

### DIFF
--- a/ipyxact/ipyxact.py
+++ b/ipyxact/ipyxact.py
@@ -78,7 +78,7 @@ class IpxactBool(str):
         if not args:
             return None
         expr = args[0].strip(' \t\n\r')
-        elif expr in ['true', 'false']:
+        if expr in ['true', 'false']:
             return super(IpxactBool, cls).__new__(cls, expr)
         else:
             raise Exception


### PR DESCRIPTION
Fix for this error in the master branch:
```
python ./ipyxact/ipyxact.py 
  File "./ipyxact/ipyxact.py", line 81
    elif expr in ['true', 'false']:
    ^
SyntaxError: invalid syntax
```
