### PR TITLE
Fixes

### DIFF
--- a/ipyxact/ipxact_yaml.py
+++ b/ipyxact/ipxact_yaml.py
@@ -196,6 +196,7 @@ register:
   MEMBERS:
     name: str
     description: str
+    dim: IpxactInt
     access: str
     addressOffset: IpxactInt
     size: IpxactInt

--- a/ipyxact/ipxact_yaml.py
+++ b/ipyxact/ipxact_yaml.py
@@ -105,6 +105,7 @@ enumeratedValues:
 reset:
   MEMBERS:
     value: IpxactInt
+    mask: IpxactInt
 resets:
   CHILD:
     - reset

--- a/ipyxact/ipyxact.py
+++ b/ipyxact/ipyxact.py
@@ -78,7 +78,7 @@ class IpxactBool(str):
         if not args:
             return None
         expr = args[0].strip(' \t\n\r')
-        elif expr in ['true', 'false']:
+        if expr in ['true', 'false']:
             return super(IpxactBool, cls).__new__(cls, expr)
         else:
             raise Exception
@@ -153,10 +153,7 @@ class IpxactItem(object):
             for f in root.findall("./{}:{}".format(ns[0], c), {ns[0] : ns[1]}):
                 child = getattr(self, c)[:]
                 class_name = c[0].upper() + c[1:]
-                t = __import__(self.__module__)
-                t = getattr(t, 'ipyxact')
-                t = getattr(t, class_name)()
-                #t = eval(class_name)()
+                t = globals()[class_name]()
                 t.parse_tree(f, ns)
                 child.append(t)
                 setattr(self, c, child)


### PR DESCRIPTION
- Incorporate https://github.com/olofk/ipyxact/pull/32  
- Use `globals()` such that ipyxact could be used as a git submodule.  
Otherwise classes generated by `_generate_classes` are inaccessible from `parse_tree` when ipyxact is imported through another hierarchy (`from ipyxact.ipyxact.ipyxact import Component`)
- Add missing `dim` attribute to `register` element and `mask` attribute to `reset` element