### PR TITLE
gen_markdown.py: print names and descriptions

### DIFF
--- a/gen_markdown.py
+++ b/gen_markdown.py
@@ -10,15 +10,24 @@ def print_memorymaps(memory_maps, offset=0, title=None):
 
 Register Map
 ------------
+
 """
     if title:
         s = s.format(title)
     else:
         s = s.format("Register map")
     for m in memory_maps.memoryMap:
+        if m.name:
+            s += "# {}\n".format(m.name)
+        if m.description:
+            s += "{}\n".format(m.description)
         for block in m.addressBlock:
+            if block.name:
+                s += "## {}\n".format(block.name)
+            if block.description:
+                s += "{}\n".format(block.description)
             for reg in sorted(block.register, key=lambda addr: addr.addressOffset):
-                s += "\n## 0x{:x} {}\n\n".format(offset+block.baseAddress+reg.addressOffset, reg.name)
+                s += "\n### 0x{:x} {}\n\n".format(offset+block.baseAddress+reg.addressOffset, reg.name)
                 if reg.description:
                     s += "{}\n\n".format(reg.description)
 

--- a/gen_markdown.py
+++ b/gen_markdown.py
@@ -38,7 +38,7 @@ Register Map
                     for f in sorted(reg.field, key=lambda x: x.bitOffset):
                         description = f.description
                         if f.enumeratedValues:
-                            description += "".join(["<br>{} = {}".format(
+                            description += "".join(["<br/>{} = {}".format(
                                 e.value, e.name) for e in f.enumeratedValues.enumeratedValue])
 
                         if f.bitWidth == 1:

--- a/gen_markdown.py
+++ b/gen_markdown.py
@@ -27,6 +27,7 @@ Register Map
             if block.description:
                 s += "{}\n".format(block.description)
             for reg in sorted(block.register, key=lambda addr: addr.addressOffset):
+                s += '\n---\n'
                 s += "\n### 0x{:x} {}\n\n".format(offset+block.baseAddress+reg.addressOffset, reg.name)
                 if reg.description:
                     s += "{}\n\n".format(reg.description)
@@ -37,8 +38,8 @@ Register Map
                     for f in sorted(reg.field, key=lambda x: x.bitOffset):
                         description = f.description
                         if f.enumeratedValues:
-                            for es in f.enumeratedValues:
-                                description += "".join(["<br>{} = {}".format(e.value, e.name) for e in es.enumeratedValue])
+                            description += "".join(["<br>{} = {}".format(
+                                e.value, e.name) for e in f.enumeratedValues.enumeratedValue])
 
                         if f.bitWidth == 1:
                             bits = f.bitOffset


### PR DESCRIPTION
Memory maps and address blocks can specify name and description.
Print them out in the Markdown file, when they are specified.