### PR TITLE
Update examples to account for addressUnitBits property

### DIFF
--- a/examples/gen_c_header.py
+++ b/examples/gen_c_header.py
@@ -80,6 +80,9 @@ def write_memory_maps(of, memory_maps, offset=0, name=None):
             mname = m.name.upper()
         multiblock = len(m.addressBlock) > 1
 
+        aub = m.addressUnitBits or 8
+        addr_scale = aub // 8
+
         for block in m.addressBlock:
             if multiblock:
                 bname = mname + '_' + block.name.upper()
@@ -89,7 +92,7 @@ def write_memory_maps(of, memory_maps, offset=0, name=None):
                 reg_name = '{}_{}'.format(
                         bname, reg.name.upper().replace('-', '_'))
                 reg_addr = '0x{:08X}'.format(
-                        offset + block.baseAddress + reg.addressOffset)
+                        offset + (block.baseAddress + reg.addressOffset) * addr_scale)
                 if reg.size in [8, 16, 32, 64]:
                     reg_access = 'RO_' if reg.access == 'read-only' else ''
                     of.write('#define {} IPYXACT_{}REG_{}({})\n'.format(

--- a/examples/gen_markdown.py
+++ b/examples/gen_markdown.py
@@ -17,6 +17,8 @@ Register Map
     else:
         s = s.format("Register map")
     for m in memory_maps.memoryMap:
+        aub = m.addressUnitBits or 8
+        addr_scale = aub // 8
         if m.name:
             s += "# {}\n".format(m.name)
         if m.description:
@@ -28,7 +30,7 @@ Register Map
                 s += "{}\n".format(block.description)
             for reg in sorted(block.register, key=lambda addr: addr.addressOffset):
                 s += '\n---\n'
-                s += "\n### 0x{:x} {}\n\n".format(offset+block.baseAddress+reg.addressOffset, reg.name)
+                s += "\n### 0x{:x} {}\n\n".format(offset+(block.baseAddress+reg.addressOffset)*addr_scale, reg.name)
                 if reg.description:
                     s += "{}\n\n".format(reg.description)
 
@@ -62,4 +64,3 @@ if __name__ == "__main__":
     offset = 0
     print(write_markdown(f, offset, title))
     f.close()
-


### PR DESCRIPTION
Hi Olof!

This PR adjusts your example C and Markdown generators to account for this (very often overlooked) feature of IP-XACT: addressUnitBits.

The IP-XACT `addressUnitBits` property defines the scale factor used for address increments. In most cases, this property is not used and defaults to 8. However often some of the "big-name" vendors will provide IP definitions that use a less common AUB value of 16 or 32 in order to communicate that the addressing is word-based rather than byte-based. This means that for every +1 increment in IP-XACT `baseAddress` or `addressOffset`, the true byte address increment is +2 or +4 respectively.
Some colleagues of mine were using your C header generator example and were confused why the resulting address offsets were off by a factor of 2.

Description from the IP-XACT spec:
![image](https://github.com/olofk/ipyxact/assets/12021539/4e4d3963-9bc0-4961-bcc7-36da64ed8043)

This diagram is another way to visualize the concept which is somewhat helpful:
![image](https://github.com/olofk/ipyxact/assets/12021539/392182db-87fc-4fa8-9778-cb05156dbb02)

- Alex